### PR TITLE
Add port conflict check

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1
+* Requires AAU1 1.30.7.0 beta.  Use 0.3.0 if you're still on the released SU11.
+* Add check for conflicting programs at startup
+
 ## 0.5.0
 * Requires AAU1 1.30.7.0 beta.  Use 0.3.0 if you're still on the released SU11.
 * Rework electrical bus logic to not require hacking panel.xml

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -8,7 +8,7 @@ const path = require('path');
 const fs = require('fs');
 const network = require('network');
 const os = require('os');
-
+const net = require('net');
 
 const readline = require('readline').createInterface({
     input: process.stdin,
@@ -90,7 +90,20 @@ for (const arg of args) {
     process.exit(1);
 }
 
-start();
+checkConflictAndStart();
+
+function checkConflictAndStart() {
+    console.log("Checking for port conflicts...");
+    const socket = new net.Socket();
+    socket.on('connect', ()=>{
+        console.error(`Another process is listening on port ${websocketPort}.`)
+        console.error("You must stop this process for the MCDU server to work.")
+        process.exit(1);
+    });
+    socket.on('error', start);
+    socket.connect(websocketPort);
+}
+
 
 function start() {
     console.log('Starting server...');


### PR DESCRIPTION
The web socket port binding seems to work if it can bind to _any_ IP on the machine.

For instance, if there's something listening on 127.0.0.1:8088, the attempt to bind to 0.0.0.0:8088 will succeed because it will bind to the other IP addresses.

This doesn't help the mod, which will always connects to localhost:8088 which will not be our server.

So, before the MCDU server starts, we will attempt to connect to localhost:8088.   If something is already listening there, we will display an error and exit.